### PR TITLE
fix: handle zero numerator in final exp of bls and bn curves

### DIFF
--- a/src/bls12_381/final_exp.cairo
+++ b/src/bls12_381/final_exp.cairo
@@ -28,7 +28,14 @@ func final_exponentiation{
         v0=input.w1, v1=input.w3, v2=input.w5, v3=input.w7, v4=input.w9, v5=input.w11
     );
     let (local circuit_input: felt*) = alloc();
-    memcpy(dst=circuit_input, src=cast(&num, felt*), len=24);
+
+    let (num_is_zero) = is_zero_E6D(num, bls.CURVE_ID);
+    if (num_is_zero == TRUE) {
+        let (one_E12: E12D) = one_E12D();
+        return (res=one_E12);
+    } else {
+        memcpy(dst=circuit_input, src=cast(&num, felt*), len=24);
+    }
 
     let (den_is_zero) = is_zero_E6D(den, bls.CURVE_ID);
     if (den_is_zero == TRUE) {

--- a/src/bn254/final_exp.cairo
+++ b/src/bn254/final_exp.cairo
@@ -28,7 +28,14 @@ func final_exponentiation{
         v0=input.w1, v1=input.w3, v2=input.w5, v3=input.w7, v4=input.w9, v5=input.w11
     );
     let (local circuit_input: felt*) = alloc();
-    memcpy(dst=circuit_input, src=cast(&num, felt*), len=24);
+
+    let (num_is_zero) = is_zero_E6D(num, bn.CURVE_ID);
+    if (num_is_zero == TRUE) {
+        let (one_E12: E12D) = one_E12D();
+        return (res=one_E12);
+    } else {
+        memcpy(dst=circuit_input, src=cast(&num, felt*), len=24);
+    }
 
     let (den_is_zero) = is_zero_E6D(den, bn.CURVE_ID);
     if (den_is_zero == TRUE) {


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Testing
- [ ] Other (please describe):

# What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Final exponentiation with numerator of E12D set to zero fails on both BLS12-381 and BN254 curves.

Issue Number: N/A

# What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Handle the case where E6D numerator is zero in final exponentiation over BLS12-381 and BN254 curves.

# Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

# Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
